### PR TITLE
timeSpec no longer needed for VS 2019

### DIFF
--- a/pthread.h
+++ b/pthread.h
@@ -315,13 +315,6 @@ enum {
 
 #if !defined(HAVE_STRUCT_TIMESPEC)
 #define HAVE_STRUCT_TIMESPEC
-#if !defined(_TIMESPEC_DEFINED)
-#define _TIMESPEC_DEFINED
-struct timespec {
-        time_t tv_sec;
-        long tv_nsec;
-};
-#endif /* _TIMESPEC_DEFINED */
 #endif /* HAVE_STRUCT_TIMESPEC */
 
 #if !defined(SIG_BLOCK)


### PR DESCRIPTION
The redefinition of timespec is the same bloc of code already implemented in VS2019. It could be interesting to delete these lines to allow correct build with VS2019 (and execution with VS redist 2019).